### PR TITLE
Fix for "TypeError: send() got an unexpected keyword argument 'raw'"

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -729,7 +729,7 @@ class FSChan(object):
         self.fs.update()
         self.cmd_stub = {'ext_nodes': {}}
 
-    def send(self, load, tries=None, timeout=None):
+    def send(self, load, tries=None, timeout=None, raw=False):  # pylint: disable=unused-argument
         '''
         Emulate the channel send method, the tries and timeout are not used
         '''


### PR DESCRIPTION
### What does this PR do?
### What issues does this PR fix or reference?
### Previous Behavior

Remove this section if not relevant
### New Behavior

Remove this section if not relevant
### Tests written?

Yes/No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
